### PR TITLE
Django allauth

### DIFF
--- a/trehacklab/requirements.txt
+++ b/trehacklab/requirements.txt
@@ -1,2 +1,3 @@
 Mezzanine==5.1.0
 fontawesome-free==5.15.4
+django-allauth==0.47.0

--- a/trehacklab/templates/admin/includes_grappelli/header.html
+++ b/trehacklab/templates/admin/includes_grappelli/header.html
@@ -1,0 +1,36 @@
+{% extends "admin/includes_grappelli/header.html" %}
+{% load i18n %}
+
+{% block userlinks %}
+        <!-- Documentation -->
+        {% url "django-admindocs-docroot" as docsroot %}
+        {% if docsroot %}
+        <li><a href="{{ docsroot }}">{% trans 'Documentation' %}</a></li>
+        {% endif %}
+        <!-- Change Password -->
+
+        {% comment hide change_password link %}
+        <!--
+                remove grappelli original password change link
+                there is no cleanly get this out. should probably do a few more
+                pr:s to mezzanine and grappelli-safe so that they could use the
+                user.has_usable_password
+        -->
+        {% url "admin:password_change" as password_change_url %}
+        {% if password_change_url %}
+        <li><a href="{{ password_change_url }}">
+        {% else %}
+        <li><a href="{{ root_path }}password_change/">
+        {% endif %}
+        {% trans 'Change password' %}</a></li>
+        {% endcomment %}
+
+        <!-- Logout -->
+        {% url "admin:logout" as logout_url %}
+        {% if logout_url %}
+        <li><a href="{{ logout_url }}">
+        {% else %}
+        <li><a href="{{ root_path }}logout/">
+        {% endif %}
+        {% trans 'Log out' %}</a></li>
+{% endblock %}

--- a/trehacklab/trehacklab/adapters.py
+++ b/trehacklab/trehacklab/adapters.py
@@ -1,0 +1,56 @@
+from django.contrib.auth.models import Group
+from django.contrib.sites.models import Site
+
+from mezzanine.core.models import SitePermission
+
+from allauth.account.adapter import DefaultAccountAdapter
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+
+
+class DisableSignUpAccountAdapter(DefaultAccountAdapter):
+    """
+    Adapter to disable allauth new signups
+    Used at settings.py with key ACCOUNT_ADAPTER
+
+    https://django-allauth.readthedocs.io/en/latest/advanced.html#custom-redirects
+    """
+
+    def is_open_for_signup(self, request):
+        """
+        Checks whether or not the site is open for signups.
+        """
+        return False
+
+
+class SocialAccountToStaffAdapter(DefaultSocialAccountAdapter):
+    def is_open_for_signup(self, request, sociallogin):
+        """
+        Allow self signup for social login
+
+        We only have keycloack so this should be fine
+        """
+        return True
+
+    def save_user(self, request, sociallogin, form=None):
+        """
+        Let super do the heavy lifting and after that add the staff status
+        and groups to our user
+        """
+        u = super().save_user(request, sociallogin, form)
+
+        u = sociallogin.user
+        # set as staff
+        u.is_staff = True
+
+        # add to SSO group
+        sso_group, created = Group.objects.get_or_create(name = 'SSO')
+        u.groups.add(sso_group)
+
+        # and give permission to all sites for this user
+        for s in Site.objects.all():
+            siteperms = SitePermission.objects.create(user=u)
+            siteperms.sites.add(s)
+
+        u.save()
+
+        return u

--- a/trehacklab/trehacklab/settings.py
+++ b/trehacklab/trehacklab/settings.py
@@ -129,7 +129,11 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = False
 
-AUTHENTICATION_BACKENDS = ("mezzanine.core.auth_backends.MezzanineBackend",)
+AUTHENTICATION_BACKENDS = [
+    "mezzanine.core.auth_backends.MezzanineBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
+]
+
 
 # The numeric mode to set newly-uploaded files to. The value should be
 # a mode you'd pass directly to os.chmod.
@@ -254,8 +258,23 @@ INSTALLED_APPS = (
     "mezzanine.blog",
     "mezzanine.forms",
     "mezzanine.galleries",
-    "fontawesome_free"
+    "fontawesome_free",
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
+    "allauth.socialaccount.providers.keycloak",
 )
+
+SOCIALACCOUNT_PROVIDERS = {
+    'keycloak': {
+        'KEYCLOAK_URL': 'https://sso.hacklab.fi/auth',
+        'KEYCLOAK_REALM': 'tampere',
+    }
+}
+SOCIALACCOUNT_AUTO_SIGNUP = True
+SOCIALACCOUNT_EMAIL_VERIFICATION = "none"
+ACCOUNT_ADAPTER = "trehacklab.adapters.DisableSignUpAccountAdapter"
+SOCIALACCOUNT_ADAPTER = 'trehacklab.adapters.SocialAccountToStaffAdapter'
 
 # List of middleware classes to use. Order is important; in the request phase,
 # these middleware classes will be applied in the order given, and in the

--- a/trehacklab/trehacklab/urls.py
+++ b/trehacklab/trehacklab/urls.py
@@ -1,10 +1,11 @@
 from __future__ import unicode_literals
 
 from django.conf.urls import include
-from django.urls import re_path
+from django.urls import re_path, path
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.views.i18n import set_language
+from django.views.generic.base import RedirectView
 
 from mezzanine.core.views import direct_to_template
 from mezzanine.blog import views as blog_views
@@ -17,7 +18,14 @@ admin.autodiscover()
 # You can also change the ``home`` view to add your own functionality
 # to the project's homepage.
 
-urlpatterns = i18n_patterns(
+# keep allauth first, this is needed for the redirect and others
+urlpatterns = [
+    path('accounts/', include('allauth.urls')),
+    path('admin/login/', RedirectView.as_view(url='/accounts/login/?next=/admin/')),
+    path('admin/logout/', RedirectView.as_view(url='/accounts/logout')),
+]
+
+urlpatterns += i18n_patterns(
     # Change the admin prefix here to use an alternate URL for the
     # admin interface, which would be marginally more secure.
     re_path("^admin/", include(admin.site.urls)),
@@ -96,6 +104,9 @@ urlpatterns += [
     # need to use the ``SITE_PREFIX`` setting as well.
 
     # ("^%s/" % settings.SITE_PREFIX, include("mezzanine.urls"))
+
+
+
 
 ]
 


### PR DESCRIPTION
Add django allauth and few settings for it.

Also adds a customer adapter that defines that no signup is possible except for social login and when social login happens the user gets assigned to "SSO" group for edit permissions and gets access to all defined sites

hides the "change password" link in admin view (it wont work anyway as the user does not have a password)