### PR TITLE
Fix SSO config confusion

### DIFF
--- a/trehacklab/templates/admin/login.html
+++ b/trehacklab/templates/admin/login.html
@@ -17,6 +17,8 @@
         <i class="fas fa-sign-in-alt"></i>
         {{provider.name}}
         </a>
+    {% empty %}
+      <p class="errornote">{% trans "No valid SSO configuration." %}</p>
     {% endfor %}
   </div>
 

--- a/trehacklab/trehacklab/settings.py
+++ b/trehacklab/trehacklab/settings.py
@@ -265,21 +265,6 @@ INSTALLED_APPS = (
     "allauth.socialaccount.providers.openid_connect",
 )
 
-SOCIALACCOUNT_PROVIDERS = {
-    "openid_connect": {
-        "SERVERS": [
-            {
-                "id": "keycloak",
-                "name": "Hacklab SSO",
-                "server_url": "https://sso.hacklab.fi/realms/tampere",
-                "APP": {
-                    "client_id": "",
-                    "secret": "",
-                },
-            }
-        ]
-    }
-}
 SOCIALACCOUNT_AUTO_SIGNUP = True
 SOCIALACCOUNT_EMAIL_VERIFICATION = "none"
 ACCOUNT_ADAPTER = "trehacklab.adapters.DisableSignUpAccountAdapter"


### PR DESCRIPTION
django-allauth didn't like having both config and SocialApp configuration

Also show a message on the login page if no valid configurations exist